### PR TITLE
feat(email-verification): 이메일 인증 로직을 Redis 기반으로 리팩터링

### DIFF
--- a/backend/user-service/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
       )
       .authorizeHttpRequests(auth -> auth
         // 열어둘 경로
+        .requestMatchers("/error").permitAll()
         .requestMatchers("/admin/**").hasRole("ADMIN")
         .requestMatchers(
           "/signup",
@@ -101,7 +102,10 @@ public class SecurityConfig {
           "/logout",               // ← 여기
           "/oauth2/**",
           "/swagger-ui/**",
-          "/v3/api-docs/**"
+          "/v3/api-docs/**",
+          "/users/email-verification/**",   // ✅ 인증 제외
+          "/users/refresh",
+          "/error" 
         ).permitAll()
         .anyRequest().authenticated()
       )

--- a/backend/user-service/src/main/java/com/example/demo/controller/EmailController.java
+++ b/backend/user-service/src/main/java/com/example/demo/controller/EmailController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/emails")
+@RequestMapping("/users/api/emails")
 @RequiredArgsConstructor
 public class EmailController {
 

--- a/backend/user-service/src/main/java/com/example/demo/controller/EmailVerificationController.java
+++ b/backend/user-service/src/main/java/com/example/demo/controller/EmailVerificationController.java
@@ -14,73 +14,75 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/email-verification")
+@RequestMapping("/users/email-verification")
 @RequiredArgsConstructor
 @Tag(name = "Email Verification", description = "이메일 인증 API")
 public class EmailVerificationController {
-    
+
     private final EmailVerificationService emailVerificationService;
-    
+
     @PostMapping("/send")
     @Operation(summary = "이메일 인증 코드 전송", description = "회원가입 시 이메일 인증 코드를 전송합니다.")
     public ResponseEntity<EmailVerificationResponse> sendVerificationCode(
             @Valid @RequestBody EmailVerificationRequest request) {
-        
+
         log.info("이메일 인증 코드 전송 요청: {}", request.getEmail());
-        
+
         EmailVerificationResponse response = emailVerificationService.sendVerificationCode(request);
-        
-        if (response.isSuccess()) {
-            return ResponseEntity.ok(response);
-        } else {
-            return ResponseEntity.badRequest().body(response);
-        }
+
+        return response.isSuccess()
+                ? ResponseEntity.ok(response)
+                : ResponseEntity.badRequest().body(response);
     }
-    
+
     @PostMapping("/confirm")
     @Operation(summary = "이메일 인증 코드 확인", description = "전송된 인증 코드를 확인하여 이메일 인증을 완료합니다.")
     public ResponseEntity<EmailVerificationResponse> confirmVerificationCode(
             @Valid @RequestBody EmailVerificationConfirmRequest request) {
-        
+
         log.info("이메일 인증 코드 확인 요청: {}", request.getEmail());
-        
-        EmailVerificationResponse response = emailVerificationService.confirmVerificationCode(request);
-        
-        if (response.isSuccess()) {
-            return ResponseEntity.ok(response);
-        } else {
-            return ResponseEntity.badRequest().body(response);
-        }
+
+        boolean verified = emailVerificationService.verifyCode(
+                request.getEmail(), request.getVerificationCode()
+        );
+
+        EmailVerificationResponse response = verified
+                ? EmailVerificationResponse.success("이메일 인증이 완료되었습니다.", request.getEmail())
+                : EmailVerificationResponse.failure("인증 코드가 올바르지 않거나 만료되었습니다.");
+
+        return verified ? ResponseEntity.ok(response) : ResponseEntity.badRequest().body(response);
     }
-    
+
     @PostMapping("/resend")
     @Operation(summary = "이메일 인증 코드 재전송", description = "인증 코드를 재전송합니다.")
     public ResponseEntity<EmailVerificationResponse> resendVerificationCode(
             @Valid @RequestBody EmailVerificationRequest request) {
-        
+
         log.info("이메일 인증 코드 재전송 요청: {}", request.getEmail());
-        
+
         EmailVerificationResponse response = emailVerificationService.resendVerificationCode(request);
-        
-        if (response.isSuccess()) {
-            return ResponseEntity.ok(response);
-        } else {
-            return ResponseEntity.badRequest().body(response);
-        }
+
+        return response.isSuccess()
+                ? ResponseEntity.ok(response)
+                : ResponseEntity.badRequest().body(response);
     }
-    
+
+    /**
+     * Redis-only 구조에서는 인증 성공 시 키를 삭제하므로
+     * 상태 조회는 '남은 인증 코드 여부'를 기준으로 반환합니다.
+     */
     @GetMapping("/status/{email}")
-    @Operation(summary = "이메일 인증 상태 확인", description = "이메일의 인증 상태를 확인합니다.")
+    @Operation(summary = "이메일 인증 상태 확인", description = "Redis 기반 인증 상태를 확인합니다. (코드 미존재 = 인증 완료)")
     public ResponseEntity<EmailVerificationResponse> checkVerificationStatus(@PathVariable String email) {
-        
+
         log.info("이메일 인증 상태 확인 요청: {}", email);
-        
-        boolean isVerified = emailVerificationService.isEmailVerified(email);
-        
-        EmailVerificationResponse response = isVerified 
-                ? EmailVerificationResponse.success("이메일이 인증되었습니다.", email)
-                : EmailVerificationResponse.failure("이메일이 인증되지 않았습니다.");
-        
+
+        boolean isPending = emailVerificationService.hasPendingVerification(email);
+
+        EmailVerificationResponse response = isPending
+                ? EmailVerificationResponse.failure("인증이 아직 완료되지 않았습니다.")
+                : EmailVerificationResponse.success("이메일 인증 완료 상태입니다.", email);
+
         return ResponseEntity.ok(response);
     }
-} 
+}

--- a/backend/user-service/src/main/java/com/example/demo/service/EmailVerificationService.java
+++ b/backend/user-service/src/main/java/com/example/demo/service/EmailVerificationService.java
@@ -7,10 +7,14 @@ import com.example.demo.dto.EmailVerificationResponse;
 import com.example.demo.repository.EmailVerificationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.RedisTemplate;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Random;
@@ -21,38 +25,31 @@ import java.util.Random;
 @Transactional
 public class EmailVerificationService {
     
-    private final EmailVerificationRepository emailVerificationRepository;
+    private final RedisTemplate<String, String> redisTemplate;
     private final EmailService emailService;
     private final Random random = new Random();
+
+    private static final Duration VERIFICATION_TTL = Duration.ofMinutes(5);
     
     /**
      * 이메일 인증 코드 전송
      */
     public EmailVerificationResponse sendVerificationCode(EmailVerificationRequest request) {
         String email = request.getEmail();
-        
         try {
-            // 기존 인증 정보가 있으면 삭제
-            emailVerificationRepository.findByEmail(email)
-                    .ifPresent(emailVerificationRepository::delete);
-            
-            // 새로운 인증 코드 생성
+            // 1. 인증 코드 생성
             String verificationCode = generateVerificationCode();
-            
-            // 인증 정보 저장
-            EmailVerification emailVerification = EmailVerification.builder()
-                    .email(email)
-                    .verificationCode(verificationCode)
-                    .build();
-            
-            emailVerificationRepository.save(emailVerification);
-            
-            // 이메일 전송
+
+            // 2. Redis에 5분 TTL로 저장
+            String redisKey = buildRedisKey(email);
+            redisTemplate.opsForValue().set(redisKey, verificationCode, VERIFICATION_TTL);
+
+            // 3. 이메일 발송
             emailService.sendVerificationEmail(email, verificationCode);
-            
-            log.info("인증 코드 전송 완료: {}", email);
+
+            log.info("인증 코드 전송 완료 (Redis 저장): {}", email);
             return EmailVerificationResponse.success("인증 코드가 이메일로 전송되었습니다.", email);
-            
+
         } catch (Exception e) {
             log.error("인증 코드 전송 실패: {}", email, e);
             return EmailVerificationResponse.failure("인증 코드 전송에 실패했습니다.");
@@ -62,107 +59,64 @@ public class EmailVerificationService {
     /**
      * 이메일 인증 코드 확인
      */
-    public EmailVerificationResponse confirmVerificationCode(EmailVerificationConfirmRequest request) {
-        String email = request.getEmail();
-        String verificationCode = request.getVerificationCode();
-        
-        try {
-            Optional<EmailVerification> verificationOpt = emailVerificationRepository
-                    .findByEmailAndVerificationCode(email, verificationCode);
-            
-            if (verificationOpt.isEmpty()) {
-                return EmailVerificationResponse.failure("인증 코드가 일치하지 않습니다.");
-            }
-            
-            EmailVerification verification = verificationOpt.get();
-            
-            // 시도 횟수 확인
-            if (!verification.canAttempt()) {
-                return EmailVerificationResponse.failure("인증 시도 횟수를 초과했습니다. 새로운 인증 코드를 요청해주세요.");
-            }
-            
-            // 만료 확인
-            if (verification.isExpired()) {
-                return EmailVerificationResponse.failure("인증 코드가 만료되었습니다. 새로운 인증 코드를 요청해주세요.");
-            }
-            
-            // 인증 성공 처리
-            verification.setVerified(true);
-            emailVerificationRepository.save(verification);
-            
-            log.info("이메일 인증 완료: {}", email);
-            return EmailVerificationResponse.success("이메일 인증이 완료되었습니다.", email);
-            
-        } catch (Exception e) {
-            log.error("인증 코드 확인 실패: {}", email, e);
-            return EmailVerificationResponse.failure("인증 처리 중 오류가 발생했습니다.");
+    public boolean verifyCode(String email, String inputCode) {
+        String redisKey = buildRedisKey(email);
+        String savedCode = redisTemplate.opsForValue().get(redisKey);
+
+        if (savedCode != null && savedCode.equals(inputCode)) {
+            // 인증 성공 시 Redis 키 삭제
+            redisTemplate.delete(redisKey);
+            log.info("이메일 인증 성공 및 Redis 키 삭제: {}", email);
+            return true;
         }
+
+        log.warn("이메일 인증 실패 - 코드 불일치 또는 만료됨: {}", email);
+        return false;
     }
     
     /**
      * 이메일 인증 상태 확인
      */
-    public boolean isEmailVerified(String email) {
-        return emailVerificationRepository.existsByEmailAndVerifiedTrue(email);
-    }
-    
-    /**
-     * 인증 코드 재전송
-     */
     public EmailVerificationResponse resendVerificationCode(EmailVerificationRequest request) {
         String email = request.getEmail();
-        
         try {
-            // 기존 인증 정보 확인
-            Optional<EmailVerification> existingVerification = emailVerificationRepository.findByEmail(email);
-            
-            if (existingVerification.isPresent()) {
-                EmailVerification verification = existingVerification.get();
-                
-                // 이미 인증된 경우
-                if (verification.isVerified()) {
-                    return EmailVerificationResponse.failure("이미 인증된 이메일입니다.");
-                }
-                
-                // 새로운 인증 코드 생성
-                String newVerificationCode = generateVerificationCode();
-                verification.setVerificationCode(newVerificationCode);
-                verification.setAttemptCount(0);
-                emailVerificationRepository.save(verification);
-                
-                // 이메일 재전송
-                emailService.sendVerificationEmail(email, newVerificationCode);
-                
-                log.info("인증 코드 재전송 완료: {}", email);
-                return EmailVerificationResponse.success("인증 코드가 재전송되었습니다.", email);
-            } else {
-                return EmailVerificationResponse.failure("인증 요청이 없습니다. 먼저 인증 코드를 요청해주세요.");
-            }
-            
+            // 1. 새 코드 생성
+            String newVerificationCode = generateVerificationCode();
+
+            // 2. 기존 키 덮어쓰기 (TTL 갱신)
+            String redisKey = buildRedisKey(email);
+            redisTemplate.opsForValue().set(redisKey, newVerificationCode, VERIFICATION_TTL);
+
+            // 3. 이메일 발송
+            emailService.sendVerificationEmail(email, newVerificationCode);
+
+            log.info("인증 코드 재전송 완료 (Redis 덮어쓰기): {}", email);
+            return EmailVerificationResponse.success("인증 코드가 재전송되었습니다.", email);
+
         } catch (Exception e) {
             log.error("인증 코드 재전송 실패: {}", email, e);
             return EmailVerificationResponse.failure("인증 코드 재전송에 실패했습니다.");
         }
     }
     
+
+    private String buildRedisKey(String email) {
+        return "email:verification:" + email;
+    }
     /**
      * 6자리 랜덤 인증 코드 생성
      */
     private String generateVerificationCode() {
         return String.format("%06d", random.nextInt(1000000));
     }
-    
-    /**
-     * 만료된 인증 정보 정리 (매일 자정 실행)
+
+        /** 
+     * Redis에 인증 대기 키 존재 여부 확인 
      */
-    @Scheduled(cron = "0 0 0 * * ?")
-    @Transactional
-    public void cleanupExpiredVerifications() {
-        try {
-            emailVerificationRepository.deleteExpiredVerifications(LocalDateTime.now());
-            log.info("만료된 이메일 인증 정보 정리 완료");
-        } catch (Exception e) {
-            log.error("만료된 이메일 인증 정보 정리 실패", e);
-        }
+    public boolean hasPendingVerification(String email) {
+        String redisKey = buildRedisKey(email);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(redisKey));
     }
+
+    
 } 

--- a/frontend/src/pages/CharacterMaker.jsx
+++ b/frontend/src/pages/CharacterMaker.jsx
@@ -1,4 +1,3 @@
-// frontend/src/pages/CharacterMaker.jsx
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -21,7 +20,9 @@ import {
 } from "lucide-react";
 import AOS from 'aos';
 import 'aos/dist/aos.css';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
+
+const imageServiceApi = createApiInstance('http://localhost:8000');
 
 
 export default function CharacterMaker({ onDone }) {
@@ -226,7 +227,7 @@ export default function CharacterMaker({ onDone }) {
     const formData = new FormData();
     formData.append("userId", userId);
     formData.append("file", file);
-    const res = await api.post("/api/ai-images", formData, {
+    const res = await imageServiceApi.post("/api/ai-images", formData, {
       headers: {
         "Content-Type": "multipart/form-data"
       }

--- a/frontend/src/pages/Community.jsx
+++ b/frontend/src/pages/Community.jsx
@@ -1,9 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
 import Navbar from '../components/Navbar';
 import { MoreHorizontal, Heart, MessageCircle, Share2, Bookmark, X, Send, Lock } from 'lucide-react';
 import PostUploadModal from '../components/PostUploadModal';
 import { getUserIdFromToken } from '../utils/jwtUtils';
+
+const userServiceApi = createApiInstance('http://localhost:8080');
+const communityServiceApi = createApiInstance('http://localhost:8083');
+const imageServiceApi = createApiInstance('http://localhost:8000');
+const orderServiceApi = createApiInstance('http://localhost:8082');
 
 // 게시글 상세+댓글 모달
 function formatRelativeTime(dateString) {
@@ -110,7 +115,7 @@ function CommunityPostDetailModal({ post, isOpen, onClose, onCommentAdded, onEdi
     if (!editCommentValue.trim()) return;
     try {
       const token = localStorage.getItem("accessToken");
-      await api.put(`/comments/${commentId}`, {
+      await communityServiceApi.put(`/comments/${commentId}`, {
         content: editCommentValue
       });
       setEditCommentId(null);
@@ -591,7 +596,7 @@ export default function Community() {
     if (!window.confirm('정말 삭제하시겠습니까?')) return;
     try {
       const token = localStorage.getItem("accessToken");
-      await api.delete(`/goods-posts/${post.id}`);
+      await communityServiceApi.delete(`/goods-posts/${post.id}`);
       alert('삭제되었습니다.');
       fetchPosts();
     } catch (err) {

--- a/frontend/src/pages/Community.jsx
+++ b/frontend/src/pages/Community.jsx
@@ -58,7 +58,7 @@ function CommunityPostDetailModal({ post, isOpen, onClose, onCommentAdded, onEdi
   const fetchComments = async () => {
     try {
       setCommentLoading(true);
-      const response = await api.get(`/comments/post/${post.id}`);
+      const response = await communityServiceApi.get(`/comments/post/${post.id}`);
       setComments(response.data);
     } catch (err) {
       console.error('댓글 조회 실패:', err);
@@ -92,7 +92,7 @@ function CommunityPostDetailModal({ post, isOpen, onClose, onCommentAdded, onEdi
     if (!window.confirm('댓글을 삭제하시겠습니까?')) return;
     try {
       const token = localStorage.getItem("accessToken");
-      await api.delete(`/comments/${commentId}`);
+      await communityServiceApi.delete(`/comments/${commentId}`);
       await fetchComments();
       if (onCommentAdded) onCommentAdded();
     } catch (err) {
@@ -303,7 +303,7 @@ function CommunityPost({ post, isLiked, likeLoading, onEdit, onDelete, onShare, 
     ));
     try {
       const token = localStorage.getItem("accessToken");
-      const response = await api.post(`/likes/${postId}`, {});
+      const response = await communityServiceApi.post(`/likes/${postId}`, {});
       const { liked, likeCount: newLikeCount } = response.data;
       setPosts(prevPosts => prevPosts.map(post =>
         post.id === postId
@@ -455,7 +455,7 @@ export default function Community() {
       }
 
       // 저장된 굿즈 이미지 가져오기 (최근 것 하나)
-      const goodsRes = await api.get(`/api/saved-goods/user/${userId}`);
+      const goodsRes = await orderServiceApi.get(`/api/saved-goods/user/${userId}`);
       
       if (goodsRes.status === 200) {
         const goodsData = goodsRes.data;
@@ -547,7 +547,7 @@ export default function Community() {
     ));
     try {
       const token = localStorage.getItem("accessToken");
-      const response = await api.post(`/likes/${postId}`, {});
+      const response = await communityServiceApi.post(`/likes/${postId}`, {});
       const { liked, likeCount: newLikeCount } = response.data;
       setPosts(prevPosts => prevPosts.map(post =>
         post.id === postId
@@ -577,7 +577,7 @@ export default function Community() {
   const handleEditPost = async ({ content, visibility, image }) => {
     try {
       const token = localStorage.getItem("accessToken");
-      await api.put(`/goods-posts/${editTargetPost.id}`, {
+      await communityServiceApi.put(`/goods-posts/${editTargetPost.id}`, {
         content,
         imageUrl: image,
         status: visibility === '나만 보기' ? 'PRIVATE' : 'ALL'

--- a/frontend/src/pages/CommunityPostDetail.jsx
+++ b/frontend/src/pages/CommunityPostDetail.jsx
@@ -1,10 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
 import Navbar from '../components/Navbar';
 import PostUploadModal from '../components/PostUploadModal';
 import { getUserIdFromToken } from '../utils/jwtUtils';
 import { MoreHorizontal, Heart, MessageCircle, Share2, Bookmark, X, Send, Lock, ArrowLeft, Edit, Trash2, CheckCircle, MoreVertical } from 'lucide-react';
+
+const userServiceApi = createApiInstance('http://localhost:8080');
+const communityServiceApi = createApiInstance('http://localhost:8083');
+const imageServiceApi = createApiInstance('http://localhost:8000');
+const orderServiceApi = createApiInstance('http://localhost:8082');
 
 function formatRelativeTime(dateString) {
   const now = new Date();
@@ -199,7 +204,7 @@ export default function CommunityPostDetail() {
       }
 
       // 저장된 굿즈 이미지 가져오기 (최근 것 하나)
-      const goodsRes = await api.get(`/api/saved-goods/user/${userId}`);
+      const goodsRes = await orderServiceApi.get(`/api/saved-goods/user/${userId}`);
       
       if (goodsRes.status === 200) {
         const goodsData = goodsRes.data;
@@ -258,7 +263,7 @@ export default function CommunityPostDetail() {
 
     try {
       const token = localStorage.getItem("accessToken");
-      await api.delete(`/goods-posts/${id}`);
+      await communityServiceApi.delete(`/goods-posts/${id}`);
       alert('게시글이 삭제되었습니다.');
       navigate('/community');
     } catch (err) {

--- a/frontend/src/pages/GoodsMaker.jsx
+++ b/frontend/src/pages/GoodsMaker.jsx
@@ -5,7 +5,7 @@ import Navbar from '../components/Navbar';
 import ReviewForm from '../components/ReviewForm.jsx';
 import ReviewSection from '../components/ReviewSection';
 import { getUserIdFromToken } from '../utils/jwtUtils';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
 import { 
   ShoppingCart, 
   Download, 
@@ -26,6 +26,9 @@ import mugCupImg from '../assets/mug_cup.jpg';
 import tShirtImg from '../assets/t_shirts.png';
 import echoBagImg from '../assets/echo_bag.png';
 import caseImg from '../assets/case.png';
+
+const imageServiceApi = createApiInstance('http://localhost:8000');
+const orderServiceApi = createApiInstance('http://localhost:8082');
 
 const goodsList = [
   { 
@@ -794,7 +797,7 @@ export default function GoodsMaker() {
       formData.append('file', file);
 
       try {
-        const res = await api.post('/api/user-goods', formData, {
+        const res = await orderServiceApi.post('/api/user-goods', formData, {
           headers: {
             'Content-Type': 'multipart/form-data'
           }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import axios from 'axios';
+import { createApiInstance } from '../utils/axiosInstance';
 import { 
   Mail, 
   Lock, 
@@ -12,6 +12,8 @@ import {
 } from 'lucide-react';
 import Navbar from '../components/Navbar';
 import { useAuth } from "../utils/useAuth";
+
+const authApi = createApiInstance('http://localhost:8080');
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -29,7 +31,7 @@ const Login = () => {
     
     // TODO: 실제 로그인 로직 구현
     try {
-      const res = await axios.post('http://localhost:8080/login', 
+            const res = await authApi.post('/login', 
         {email,
         password},
          { withCredentials: true } 

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -229,7 +229,7 @@ const MyPage = () => {
       if (token) {
         try {
           console.log("🔄 주문 내역 API 호출 중...");
-          const ordersResponse = await api.get('/orders/my-orders');
+          const ordersResponse = await orderServiceApi.get('/orders/my-orders');
           
           console.log("📦 주문 내역 원본 데이터:", ordersResponse.data);
           console.log("📊 주문 개수:", ordersResponse.data?.length || 0);
@@ -376,7 +376,7 @@ const MyPage = () => {
       }
 
       console.log("🔄 주문내역 API 호출 중...");
-      const response = await api.get('/orders/my-orders');
+      const response = await orderServiceApi.get('/orders/my-orders');
       
       console.log("📦 주문내역 API 응답:", response.data);
       console.log("📊 주문 개수:", response.data?.length || 0);
@@ -594,7 +594,7 @@ const MyPage = () => {
         alert("JWT 토큰이 없습니다.");
         return;
       }
-      const res = await api.put('/users/me/password', { currentPassword, newPassword });
+      const res = await userServiceApi.put('/users/me/password', { currentPassword, newPassword });
       alert('비밀번호가 성공적으로 변경되었습니다.');
       setShowPasswordForm(false);
       setCurrentPassword('');
@@ -926,7 +926,7 @@ const MyPage = () => {
         setAiImages(prevImages => prevImages.filter(img => img.id !== imageId));
       } else {
         // 방법 2: 요청 본문에 userId 포함하여 재시도
-        const res2 = await api.delete(`/api/ai-images/${imageId}`, {
+        const res2 = await imageServiceApi.delete(`/api/ai-images/${imageId}`, {
           data: { userId }
         });
 

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { useLogout } from '../utils/useLogout';
 import { getUserIdFromToken } from '../utils/jwtUtils';
 import { reviewAPIService } from '../utils/reviewAPI';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
 import { 
   User, 
   ShoppingBag, 
@@ -22,6 +22,11 @@ import Navbar from '../components/Navbar';
 import { useNavigate, Link } from 'react-router-dom';
 import ReviewModal from '../components/ReviewModal';
 import { useAuth } from "../utils/useAuth";
+
+const userServiceApi = createApiInstance('http://localhost:8080');
+const orderServiceApi = createApiInstance('http://localhost:8082');
+const communityServiceApi = createApiInstance('http://localhost:8083');
+const imageServiceApi = createApiInstance('http://localhost:8000');
 
 const MyPage = () => {
 
@@ -957,7 +962,7 @@ const MyPage = () => {
           }
           console.log("AI 이미지 불러오기:", userId);
           
-          const res = await api.get(`/api/ai-images/user/${userId}`);
+          const res = await imageServiceApi.get(`/api/ai-images/user/${userId}`);
           
           if (res.status === 200) {
             const data = res.data;

--- a/frontend/src/pages/OrderComplete.jsx
+++ b/frontend/src/pages/OrderComplete.jsx
@@ -1,9 +1,13 @@
 import { useNavigate, useLocation } from "react-router-dom";
-import api from "../utils/axiosInstance";
+import { createApiInstance } from '../utils/axiosInstance';
 import Navbar from "../components/Navbar";
 import { ArrowLeft } from "lucide-react";
 import { useState, useEffect } from "react";
 import PostUploadModal from "../components/PostUploadModal";
+
+const userServiceApi = createApiInstance('http://localhost:8080');
+const imageServiceApi = createApiInstance('http://localhost:8000');
+const communityServiceApi = createApiInstance('http://localhost:8083');
 
 export default function OrderComplete() {
   const navigate = useNavigate();
@@ -54,7 +58,7 @@ export default function OrderComplete() {
   const handlePost = async (post) => {
     try {
       const token = localStorage.getItem("accessToken");
-      const response = await api.post(
+      const response = await communityServiceApi.post(
         "/goods-posts",
         {
           content: post.content,

--- a/frontend/src/pages/OrderPage.jsx
+++ b/frontend/src/pages/OrderPage.jsx
@@ -4,7 +4,10 @@ import Navbar from "../components/Navbar";
 import { ArrowLeft } from "lucide-react";
 import Modal from "../components/Modal";
 import { getUserIdFromToken } from '../utils/jwtUtils';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
+
+const userServiceApi = createApiInstance('http://localhost:8080');
+const orderServiceApi = createApiInstance('http://localhost:8082');
 
 const OrderPage = () => {
   const location = useLocation();
@@ -265,7 +268,7 @@ const OrderPage = () => {
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
     if (!token) return;
-    api.get("/users/me")
+    userServiceApi.get("/users/me")
       .then(res => {
         console.log("[OrderPage] /me API status:", res.status);
         return res.data;

--- a/frontend/src/pages/PaySuccess.jsx
+++ b/frontend/src/pages/PaySuccess.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import Cookies from 'js-cookie';
-import api from '../utils/axiosInstance';
+import { createApiInstance } from '../utils/axiosInstance';
+
+const orderServiceApi = createApiInstance('http://localhost:8082');
 
 export default function PaySuccess() {
   const location = useLocation();
@@ -70,7 +72,7 @@ export default function PaySuccess() {
       })
         .then(data => {
           const token = localStorage.getItem("accessToken");
-          api.post("/orders/direct", {
+          orderServiceApi.post("/orders/direct", {
             goodsId: finalGoodsId,
             goodsName: finalGoodsName,
             quantity: quantityValue,

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -72,8 +72,8 @@ const isValidName = (name) => name.trim().length >= 2;
     // TODO: 실제 회원가입 로직 구현
     try {
     // 1) POST 요청: /signup (회원가입)
-    const response = await axios.post(
-      'http://localhost:8080/signup',      // 백엔드 URL을 실제 주소로 바꿔주세요
+    const response = await authApi.post(
+      '/signup',      // 백엔드 URL을 실제 주소로 바꿔주세요
       {
         username:            formData.name,
         email:           formData.email,

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import axios from 'axios';
+import { createApiInstance } from '../utils/axiosInstance';
+
+const authApi = createApiInstance('http://localhost:8080');
 import { 
   Mail, 
   Lock, 
@@ -31,6 +33,10 @@ const Signup = () => {
     privacy: false,
     marketing: false
   });
+  const [emailVerificationCode, setEmailVerificationCode] = useState('');
+  const [isVerificationCodeSent, setIsVerificationCodeSent] = useState(false);
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [verificationError, setVerificationError] = useState('');
 
   //유효성 검사 로직 
   // 이메일 유효성 검사
@@ -61,10 +67,34 @@ const isValidName = (name) => name.trim().length >= 2;
     }));
   };
 
+  const handleSendVerificationCode = async () => {
+    if (!isValidEmail(formData.email)) {
+      setVerificationError('올바른 이메일 주소를 입력해주세요.');
+      return;
+    }
+    try {
+      await authApi.post('/api/v1/email-verification/send', { email: formData.email });
+      setIsVerificationCodeSent(true);
+      setVerificationError('인증 코드가 발송되었습니다. 이메일을 확인해주세요.');
+    } catch (error) {
+      setVerificationError('인증 코드 발송에 실패했습니다.');
+    }
+  };
+
+  const handleConfirmVerificationCode = async () => {
+    try {
+      await authApi.post('/api/v1/email-verification/confirm', { email: formData.email, code: emailVerificationCode });
+      setIsEmailVerified(true);
+      setVerificationError('이메일 인증이 완료되었습니다.');
+    } catch (error) {
+      setVerificationError('인증 코드가 올바르지 않습니다.');
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!isFormValid()) {
-    setError("입력값을 다시 확인해주세요.");
+    if (!isFormValid() || !isEmailVerified) {
+    setError("입력값을 다시 확인해주세요. 이메일 인증이 필요합니다.");
     return;
     }
     setIsLoading(true);
@@ -112,7 +142,8 @@ const isValidName = (name) => name.trim().length >= 2;
       formData.password === formData.confirmPassword &&
       isValidPhone(formData.phone) &&
       agreements.terms &&
-      agreements.privacy
+      agreements.privacy &&
+      isEmailVerified
     );
   };
 
@@ -191,10 +222,56 @@ const isValidName = (name) => name.trim().length >= 2;
                     onChange={handleInputChange}
                     className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     placeholder="your@email.com"
+                    disabled={isVerificationCodeSent || isEmailVerified} // 인증 코드 발송 후 비활성화
                   />
+                  {!isEmailVerified && ( // 인증 완료 전까지 버튼 표시
+                    <button
+                      type="button"
+                      onClick={handleSendVerificationCode}
+                      disabled={!isValidEmail(formData.email) || isVerificationCodeSent}
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm font-medium text-blue-600 hover:text-blue-500 disabled:text-gray-400 disabled:cursor-not-allowed"
+                    >
+                      {isVerificationCodeSent ? '재전송' : '인증 코드 받기'}
+                    </button>
+                  )}
                 </div>
                 {formData.email && !isValidEmail(formData.email) && (
                   <p className="mt-1 text-xs text-red-500">올바른 이메일 주소를 입력하세요.</p>
+                )}
+                {isVerificationCodeSent && !isEmailVerified && (
+                  <div className="mt-4">
+                    <label htmlFor="verificationCode" className="block text-sm font-medium text-gray-700 mb-2">
+                      인증 코드
+                    </label>
+                    <div className="relative">
+                      <input
+                        id="verificationCode"
+                        name="verificationCode"
+                        type="text"
+                        required
+                        value={emailVerificationCode}
+                        onChange={(e) => setEmailVerificationCode(e.target.value)}
+                        className="block w-full px-3 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        placeholder="인증 코드 입력"
+                        disabled={isEmailVerified}
+                      />
+                      {!isEmailVerified && (
+                        <button
+                          type="button"
+                          onClick={handleConfirmVerificationCode}
+                          disabled={!emailVerificationCode.trim()}
+                          className="absolute inset-y-0 right-0 pr-3 flex items-center text-sm font-medium text-blue-600 hover:text-blue-500 disabled:text-gray-400 disabled:cursor-not-allowed"
+                        >
+                          확인
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+                {verificationError && (
+                  <p className={`mt-1 text-xs ${isEmailVerified ? 'text-green-500' : 'text-red-500'}`}>
+                    {verificationError}
+                  </p>
                 )}
               </div>
 

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -73,7 +73,7 @@ const isValidName = (name) => name.trim().length >= 2;
       return;
     }
     try {
-      await authApi.post('/api/v1/email-verification/send', { email: formData.email });
+      await authApi.post('/users/email-verification/send', { email: formData.email });
       setIsVerificationCodeSent(true);
       setVerificationError('인증 코드가 발송되었습니다. 이메일을 확인해주세요.');
     } catch (error) {
@@ -83,7 +83,7 @@ const isValidName = (name) => name.trim().length >= 2;
 
   const handleConfirmVerificationCode = async () => {
     try {
-      await authApi.post('/api/v1/email-verification/confirm', { email: formData.email, code: emailVerificationCode });
+      await authApi.post('/users/email-verification/confirm', { email: formData.email, verificationCode: emailVerificationCode });
       setIsEmailVerified(true);
       setVerificationError('이메일 인증이 완료되었습니다.');
     } catch (error) {

--- a/frontend/src/utils/axiosInstance.js
+++ b/frontend/src/utils/axiosInstance.js
@@ -1,84 +1,109 @@
 import axios from 'axios';
 
-const api = axios.create({
-  baseURL: 'http://localhost:8080',  // 백엔드 주소
-  withCredentials: true,            // 쿠키 전송 허용
+// 토큰 재발급 전용 axios 인스턴스 (항상 User Service로 요청)
+const refreshApi = axios.create({
+  baseURL: 'http://localhost:8080',
+  withCredentials: true,
 });
 
-// 초기 Authorization 헤더 세팅
-const accessToken = localStorage.getItem('accessToken');
-if (accessToken) {
-  api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-}
-
-let isRefreshing = false;
-let failedQueue = [];
-
-const processQueue = (error, token = null) => {
-  failedQueue.forEach(prom => {
-    if (error) {
-      prom.reject(error);
-    } else {
-      prom.resolve(token);
-    }
+/**
+ * MSA 환경에 맞춰, 각 서비스의 baseURL을 입력받아 axios 인스턴스를 생성합니다.
+ * 이 인스턴스는 401 오류 발생 시 자동으로 토큰 재발급을 시도합니다.
+ * 토큰 재발급 요청은 항상 User Service(8080)로 전송됩니다.
+ * @param {string} baseURL - 요청을 보낼 서비스의 기본 URL
+ */
+export function createApiInstance(baseURL) {
+  const api = axios.create({
+    baseURL, // 각 서비스의 baseURL 사용
+    withCredentials: true,
   });
-  failedQueue = [];
-};
 
-api.interceptors.request.use(
-  (config) => {
-    // 항상 로컬스토리지의 최신 토큰을 헤더에 실어 보냄
-    const token = localStorage.getItem('accessToken');
-    if (token) {
-      config.headers['Authorization'] = `Bearer ${token}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
-
-api.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    const originalRequest = error.config;
-
-    // 401이면 토큰 재발급 시도
-    if (error.response && error.response.status === 401 && !originalRequest._retry) {
-      if (isRefreshing) {
-        return new Promise((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        })
-        .then(token => {
-          originalRequest.headers['Authorization'] = `Bearer ${token}`;
-          return api(originalRequest);
-        })
-        .catch(err => Promise.reject(err));
-      }
-
-      originalRequest._retry = true;
-      isRefreshing = true;
-
-      try {
-        // refresh 호출 (쿠키 기반)
-        const res = await api.post('/users/refresh', {}, { withCredentials: true });
-        const newAccessToken = res.data.accessToken;
-
-        // 로컬스토리지와 Axios 전역 헤더 갱신
-        localStorage.setItem('accessToken', newAccessToken);
-        api.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
-        processQueue(null, newAccessToken);
-
-        return api(originalRequest); // 실패했던 요청 재시도
-      } catch (err) {
-        processQueue(err, null);
-        return Promise.reject(err);
-      } finally {
-        isRefreshing = false;
-      }
-    }
-
-    return Promise.reject(error);
+  // 초기 Authorization 헤더 세팅
+  const accessToken = localStorage.getItem('accessToken');
+  if (accessToken) {
+    api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
   }
-);
 
-export default api;
+  let isRefreshing = false;
+  let failedQueue = [];
+
+  const processQueue = (error, token = null) => {
+    failedQueue.forEach(prom => {
+      if (error) {
+        prom.reject(error);
+      } else {
+        prom.resolve(token);
+      }
+    });
+    failedQueue = [];
+  };
+
+  // 요청 인터셉터: 모든 요청에 인증 토큰 추가
+  api.interceptors.request.use(
+    (config) => {
+      const token = localStorage.getItem('accessToken');
+      if (token) {
+        config.headers['Authorization'] = `Bearer ${token}`;
+      }
+      return config;
+    },
+    (error) => Promise.reject(error)
+  );
+
+  // 응답 인터셉터: 401 오류 시 토큰 재발급 처리
+  api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config;
+
+      // 401 에러이고, 재시도한 요청이 아닐 경우
+      if (error.response && error.response.status === 401 && !originalRequest._retry) {
+        if (isRefreshing) {
+          // 이미 토큰 재발급이 진행 중인 경우, 큐에 추가
+          return new Promise((resolve, reject) => {
+            failedQueue.push({ resolve, reject });
+          })
+            .then(token => {
+              originalRequest.headers['Authorization'] = `Bearer ${token}`;
+              return api(originalRequest);
+            })
+            .catch(err => Promise.reject(err));
+        }
+
+        originalRequest._retry = true;
+        isRefreshing = true;
+
+        try {
+          // User Service (8080) 로 토큰 재발급 요청
+          const res = await refreshApi.post('/users/refresh');
+          const newAccessToken = res.data.accessToken;
+
+          localStorage.setItem('accessToken', newAccessToken);
+
+          // 새로 발급받은 토큰으로 기본 헤더 설정
+          api.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
+          // 실패했던 원래 요청의 헤더도 변경
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+
+          // 대기 중이던 모든 요청에 새 토큰으로 재시도
+          processQueue(null, newAccessToken);
+
+          // 원래 요청을 다시 실행
+          return api(originalRequest);
+        } catch (err) {
+          processQueue(err, null);
+          console.error("토큰 재발급 실패:", err);
+          // 재발급 실패 시 로그인 페이지로 리디렉션 또는 다른 처리
+          // 예: localStorage.clear(); window.location.href = '/login';
+          return Promise.reject(err);
+        } finally {
+          isRefreshing = false;
+        }
+      }
+
+      return Promise.reject(error);
+    }
+  );
+
+  return api;
+}

--- a/frontend/src/utils/useLogout.js
+++ b/frontend/src/utils/useLogout.js
@@ -1,15 +1,17 @@
 // src/hooks/useLogout.js
 import { useNavigate } from 'react-router-dom';
 import { useCallback } from 'react';
-import axios from 'axios';
+import { createApiInstance } from './axiosInstance';
+
+const authApi = createApiInstance('http://localhost:8080');
 
 export function useLogout(setIsLoggedIn) {
   const navigate = useNavigate();
 
   return useCallback(async () => {
     console.log('🔒 start logout api');
-        await axios.post('http://localhost:8080/logout',{}, { withCredentials: true });
-        console.log('✅ logout API success');
+    await authApi.post('/logout', {});
+    console.log('✅ logout API success');
     localStorage.clear();
     sessionStorage.clear();
     setIsLoggedIn(false);


### PR DESCRIPTION
### 변경 내용
- 기존 JPA 기반 EmailVerification 엔티티 및 Repository 의존성 제거
- 인증 코드를 Redis에 TTL 5분으로 저장하도록 변경
- 인증 성공 시 Redis 키 삭제 처리
- 컨트롤러 및 DTO 구조를 Redis 기반으로 수정
- 프론트엔드 요청 JSON 키를 `verificationCode`로 통일

### 변경 이유
- DB 대신 Redis를 사용해 인증 코드를 임시 저장함으로써 성능 향상
- 인증 정보는 휘발성 데이터이므로 RDBMS에 저장할 필요가 없음
- 인증 코드 만료(5분) 이후 자동 삭제로 데이터 관리 간소화

### 테스트
- 이메일 발송 정상 동작 확인
- Redis에 인증 코드 저장/만료 확인
- 프론트엔드에서 인증 코드 확인 로직 정상 동작 확인
